### PR TITLE
Use preserve-modes in revert-buffer call

### DIFF
--- a/rufo.el
+++ b/rufo.el
@@ -24,7 +24,7 @@
   (when (rufo-is-ruby-file?)
     (progn
       (shell-command (format "rufo %s" buffer-file-name))
-      (revert-buffer nil t))))
+      (revert-buffer nil t t))))
 
 (defun rufo-installed? ()
   "Verify that the binary rufo is present in the system's path."


### PR DESCRIPTION
I'm a [Spacemacs](spacemacs.org) user and would like to include your package there. I was doing some tests with some local code and I figured that, unless we add the `preserve-modes` option, the `revert-buffer` call breaks there with the following error:

```
File mode specification error: (error Format specifier doesn’t match argument type)
```

So, given that the option seems harmless (from the docs,
> Optional third argument PRESERVE-MODES non-nil means don’t alter
> the files modes.  Normally we reinitialize them using ‘normal-mode’.

), do you mind adding it?